### PR TITLE
plot >2 secrets in scatterplot

### DIFF
--- a/src/de/fau/pi1/timerReporter/plots/Scatterplot.java
+++ b/src/de/fau/pi1/timerReporter/plots/Scatterplot.java
@@ -43,13 +43,8 @@ public class Scatterplot extends Plot {
 
 		StringBuilder secrets = new StringBuilder();
 		for(int i = 0; i < dataset.getSecrets().size(); i++){
-			if(i == 0) {
-				secrets.append("\"" + "reportingTool_tmp" + gSep + uniqueName + "-" + "scatterplot_" + dataset.getSecrets().get(i).getFileName() + ".txt" + "\"" +
-						" using 1:2 title \"Secret " + dataset.getSecrets().get(i).getName().replaceAll("([\\\\{}_\\^#&$%~\"])", "") + "\" with points pt 2");
-			} else if(i == 1) {
-				secrets.append("\"" + "reportingTool_tmp" + gSep + uniqueName + "-" + "scatterplot_" + dataset.getSecrets().get(i).getFileName() + ".txt" + "\"" +
-						" using 1:2 title \"Secret " + dataset.getSecrets().get(i).getName().replaceAll("([\\\\{}_\\^#&$%~\"])", "") + "\" with points pt 6"); //or circles lt 3
-			}
+			secrets.append("\"" + "reportingTool_tmp" + gSep + uniqueName + "-" + "scatterplot_" + dataset.getSecrets().get(i).getFileName() + ".txt" + "\"" +
+						" using 1:2 title \"Secret " + dataset.getSecrets().get(i).getName().replaceAll("([\\\\{}_\\^#&$%~\"])", "") + "\" with points"); //or circles lt 3
 			if((i + 1) < dataset.getSecrets().size()) {
 				secrets.append(",\\\n");
 			}


### PR DESCRIPTION
`mona-timing-report` did not plot more than 2 secrets in a scatterplot. I don't think this is intended, as all other plots plot more than two secrets.

scatterplot example from [Botan](https://github.com/randombit/botan) bleichenbacher test with **4** secrets:

Before:
**scatterplot broken: empty file**


After:
![21-scatterplot-40-50](https://cloud.githubusercontent.com/assets/9832906/23311249/b9cfdb84-fab5-11e6-9abe-c1dcee28e4c8.png)

scatterplot example from [Botan](https://github.com/randombit/botan) ecdsa timing test with **3** secrets:

Before:
![21-scatterplot-40-50](https://cloud.githubusercontent.com/assets/9832906/23311637/10f9f84e-fab7-11e6-901c-9b179905e2e4.png)

After:
![21-scatterplot-40-50](https://cloud.githubusercontent.com/assets/9832906/23311677/2cabdb5c-fab7-11e6-890f-411e3ee1ca16.png)
