### PR TITLE
Remove invalid "xtics" value from boxplot (gnuplot) template

### DIFF
--- a/templates/plots/boxPlot-plt.txt
+++ b/templates/plots/boxPlot-plt.txt
@@ -6,7 +6,7 @@ unset parametric
 unset polar
 set xlabel "Secrets"
 set ylabel "Time"
-set xtics 0
+unset xtics
 set terminal ::terminal:::
 set output "::output:::"
 set boxwidth 0.8 absolute


### PR DESCRIPTION
The line `set xtics 0` is not valid in gnuplot. With the current template, the boxplot images will not be generated.
Using `unset xtics` removes ticks from the plot. This might be the desired behavior.